### PR TITLE
Change method name 'with' to 'createBuilder',  'resource' to 'newImageResource', 'tiling' to 'setTiling'

### DIFF
--- a/RxCamera/src/main/java/com/vondear/camera/tool/RxCameraTool.java
+++ b/RxCamera/src/main/java/com/vondear/camera/tool/RxCameraTool.java
@@ -170,7 +170,7 @@ public class RxCameraTool {
                     os.write(data);
                     os.close();
 
-                    RxMagic.with(mContext).
+                    RxMagic.createBuilder(mContext).
                             load(cachefile).
                             setCompressListener(new OnCompressListener() {
                                 @Override

--- a/RxKit/src/main/java/com/vondear/rxtool/module/photomagic/RxMagic.java
+++ b/RxKit/src/main/java/com/vondear/rxtool/module/photomagic/RxMagic.java
@@ -40,7 +40,7 @@ public class RxMagic implements Handler.Callback {
         mHandler = new Handler(Looper.getMainLooper(), this);
     }
 
-    public static Builder with(Context context) {
+    public static Builder createBuilder(Context context) {
         return new Builder(context);
     }
 

--- a/RxUI/src/main/java/com/vondear/rxui/view/dialog/RxDialogScaleView.java
+++ b/RxUI/src/main/java/com/vondear/rxui/view/dialog/RxDialogScaleView.java
@@ -102,7 +102,7 @@ public class RxDialogScaleView extends RxDialog {
 
     public void setImage(int resId) {
         this.resId = resId;
-        mRxScaleImageView.setImage(ImageSource.resource(resId));
+        mRxScaleImageView.setImage(ImageSource.newImageResource(resId));
     }
 
     public void setImage(Bitmap bitmap) {

--- a/RxUI/src/main/java/com/vondear/rxui/view/scaleimage/ImageSource.java
+++ b/RxUI/src/main/java/com/vondear/rxui/view/scaleimage/ImageSource.java
@@ -151,7 +151,7 @@ public final class ImageSource {
      * @return this instance for chaining.
      */
     public ImageSource tilingEnabled() {
-        return tiling(true);
+        return setTiling(true);
     }
 
     /**
@@ -161,7 +161,7 @@ public final class ImageSource {
      * @return this instance for chaining.
      */
     public ImageSource tilingDisabled() {
-        return tiling(false);
+        return setTiling(false);
     }
 
     /**
@@ -170,7 +170,7 @@ public final class ImageSource {
      *
      * @return this instance for chaining.
      */
-    public ImageSource tiling(boolean tile) {
+    public ImageSource setTiling(boolean tile) {
         this.tile = tile;
         return this;
     }

--- a/RxUI/src/main/java/com/vondear/rxui/view/scaleimage/ImageSource.java
+++ b/RxUI/src/main/java/com/vondear/rxui/view/scaleimage/ImageSource.java
@@ -71,7 +71,7 @@ public final class ImageSource {
      *
      * @param resId resource ID.
      */
-    public static ImageSource resource(int resId) {
+    public static ImageSource newImageResource(int resId) {
         return new ImageSource(resId);
     }
 

--- a/RxUI/src/main/java/com/vondear/rxui/view/scaleimage/RxScaleImageView.java
+++ b/RxUI/src/main/java/com/vondear/rxui/view/scaleimage/RxScaleImageView.java
@@ -310,7 +310,7 @@ public class RxScaleImageView extends View {
             if (typedAttr.hasValue(R.styleable.RxScaleImageView_src)) {
                 int resId = typedAttr.getResourceId(R.styleable.RxScaleImageView_src, 0);
                 if (resId > 0) {
-                    setImage(ImageSource.resource(resId).tilingEnabled());
+                    setImage(ImageSource.newImageResource(resId).tilingEnabled());
                 }
             }
             if (typedAttr.hasValue(R.styleable.RxScaleImageView_panEnabled)) {


### PR DESCRIPTION
The class RxMagic is used to represent RXMagic.  This method named 'with' is to create builder. Thus, the method name 'createBuilder' is more intuitive than 'with'.

The class ImageResource is used to manage the ImageResource.  This method named 'resource' is to create an instance of image from ImageResource. Thus, the method name 'newImageResource' is more intuitive than 'resource'.

The class ImageResource is used to manage ImageSource.  This method named 'tiling' is to enable tiling. Thus, the method name 'setTiling' is more intuitive than 'tiling'.