### PR TITLE
Fix readFile2List readLine return null cause error

### DIFF
--- a/RxKit/src/main/java/com/tamsiree/rxkit/RxFileTool.kt
+++ b/RxKit/src/main/java/com/tamsiree/rxkit/RxFileTool.kt
@@ -1676,7 +1676,7 @@ class RxFileTool {
             }
             var reader: BufferedReader? = null
             return try {
-                var line: String
+                var line: String?
                 var curLine = 1
                 val list: MutableList<String> = ArrayList()
                 reader = if (isNullString(charsetName)) {
@@ -1689,7 +1689,7 @@ class RxFileTool {
                         break
                     }
                     if (st <= curLine && curLine <= end) {
-                        list.add(line)
+                        list.add(line!!)
                     }
                     ++curLine
                 }


### PR DESCRIPTION
实际使用中遇到的问题，报错信息：
java.lang.IllegalStateException: it must not be null